### PR TITLE
fix script

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/install-packages.sh
+++ b/.github/actions/alpine-pandoc-hugo/install-packages.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+## Update TeX Live Manager
+tlmgr update --self || exit 1
+
 ## Install extra packages for Beamer/Metropolis
 tlmgr install beamertheme-metropolis pgfopts tcolorbox environ || exit 1
 


### PR DESCRIPTION
Fixes #60

Aktualisere TeX Live Manager vor der Installation von weiteren Packeten.

