### PR TITLE
use new base url (ilias)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-baseURL: "https://compilerbau.github.io/Lecture/"
+#baseURL: "https://compilerbau.github.io/Lecture/"
+baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1165993/"
 
 languageCode: "de-DE"
 metaDataFormat: "yaml"


### PR DESCRIPTION
let's switch to ilias. this would introduce the new base-url for the html learning module.
