### PR TITLE
use external docker image

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/action.yml
+++ b/.github/actions/alpine-pandoc-hugo/action.yml
@@ -7,6 +7,6 @@ inputs:
     default: 'make'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'ghcr.io/compilerbau/alpine-pandoc-hugo:latest'
   args:
     - export DOCKER=false; ${{ inputs.make-target }}

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -11,18 +11,22 @@ jobs:
   # build gh-page
   gh-page:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
-          export DOCKER=false; make web
-      - uses: peaceiris/actions-gh-pages@v3
+
+      - name: Pull docker image
+        run: |
+          docker pull ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+
+      - name: Build website
+        uses: ./.github/actions/alpine-pandoc-hugo
+        with:
+          make-target: 'make web'
+
+      - name: Publish website
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -11,13 +11,17 @@ jobs:
   # build gh-page
   gh-page:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: ./.github/actions/alpine-pandoc-hugo
-        with:
-          make-target: 'make web'
+      - run: |
+          export DOCKER=false; make web
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slides.yaml
+++ b/.github/workflows/slides.yaml
@@ -15,18 +15,29 @@ jobs:
   single-slide:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
-          export DOCKER=false; make ${{ github.head_ref }}
-      - uses: actions/upload-artifact@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull docker image
+        run: |
+          docker pull ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+
+      - name: Generate single slide set
+        uses: ./.github/actions/alpine-pandoc-hugo
+        with:
+          make-target: 'make ${{ github.head_ref }}'
+
+      - name: Upload generated slides
+        uses: actions/upload-artifact@v2
         with:
           path: pdf/
           retention-days: 1
@@ -35,18 +46,29 @@ jobs:
   all-slidedesks:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - run: |
-          export DOCKER=false; make slides
-      - uses: actions/upload-artifact@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull docker image
+        run: |
+          docker pull ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+
+      - name: Generate all slides
+        uses: ./.github/actions/alpine-pandoc-hugo
+        with:
+          make-target: 'make slides'
+
+      - name: Upload generated slides
+        uses: actions/upload-artifact@v2
         with:
           path: pdf/
           retention-days: 1

--- a/.github/workflows/slides.yaml
+++ b/.github/workflows/slides.yaml
@@ -15,13 +15,17 @@ jobs:
   single-slide:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: ./.github/actions/alpine-pandoc-hugo
-        with:
-          make-target: 'make ${{ github.head_ref }}'
+      - run: |
+          export DOCKER=false; make ${{ github.head_ref }}
       - uses: actions/upload-artifact@v2
         with:
           path: pdf/
@@ -31,13 +35,17 @@ jobs:
   all-slidedesks:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/compilerbau/alpine-pandoc-hugo:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: ./.github/actions/alpine-pandoc-hugo
-        with:
-          make-target: 'make slides'
+      - run: |
+          export DOCKER=false; make slides
       - uses: actions/upload-artifact@v2
         with:
           path: pdf/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 ## Launch the tools directly:              export DOCKER=false; make TARGET
 ##
 ## By default, a custom Docker image will be used. To create this
-## image, run: make create-docker-image
+## image, clone the repository https://github.com/Compilerbau/DockerImage
+## and run: make
 ##
 ## Note: LaTeX needs to be called in the folder of the .tex file to
 ## be processed. In the target "$(ALGORITHM)", the variable "$<" is
@@ -153,10 +154,6 @@ PHONY: new_assignment
 new_assignment:
 	$(HUGO) new -c "$(ORIG_CONTENT)/" -k assignment $(TOPIC)
 
-## Build Docker image "alpine-pandoc-hugo"
-.PHONY: create-docker-image
-create-docker-image:
-	cd .github/actions/alpine-pandoc-hugo && make clean all
 
 ## Clean up
 .PHONY: clean


### PR DESCRIPTION
Fixes #19

- maintain build scripts in a separate repository
- a pre-build image is stored in the Github container registry
- actions just pull the image from the repository

