### PR TITLE
PEG Example, Notes und Slides mischen

### DIFF
--- a/markdown/parsing/parsercombinator/index.md
+++ b/markdown/parsing/parsercombinator/index.md
@@ -126,44 +126,47 @@ Nur das Wissen über Erfolg oder Miserfolg wird gespeichert (siehe Beispiel zu N
 
 ## PEG Eigenschaften
 
-:::notes
-- andere Sprachklasse als CFGs
-    - PEGs können alle deterministischen LR(k)-Sprachen darstellen
-    - PEGs können manche nicht-CFG Sprachen darstellen (z.B. $a^n b^n c^n$)
-    - ungelöste Frage: Sind alle CFGs durch PEGs darstellbar?
-- parsebar in linearer Zeit mit unbegrenztem Lookahead (Packrat
-  Parsing)
-    - Nachteil: gesamter zu parsender Text muss im Speicher gehalten werden
-    - Speicherplatz ist heute aber keine große Einschränkung mehr
-    - Quellcode-Dateien sind meist nur im KB-Bereich
-- neue Möglichkeiten für das Syntax-Design von Sprachen
-    - aber auch neue Möglichkeiten für Fehler durch Unachtsamkeit
-- Syntaxbeschreibung: keine Unterscheidung zwischen Hierarchie und
-  lexikalischen Elementen nötig
-    - für gewöhnlich Hierarchie durch CFG und lex. Elem. durch RE beschrieben
-        - CFGs ungeeignet für lex. Elemente (keine Greedy-Matching, keine 'negative' Syntax)
-        - REs: keine rekursive Syntax
-    - Tokens können hierarchische Eigenschaften haben (verschachtelte Kommentare)
-    - beliebige Escape-Sequenzen möglich
-- Herausforderung bei PEGs:
-    - sind Alternativen vertauschbar, ohne die Sprache zu ändern?
-    - Analog zur Frage der Mehrdeutigkeit bei CFGs
+-   andere Sprachklasse als CFGs
 
-:::
+    ::: notes
+    -   PEGs können alle deterministischen LR(k)-Sprachen darstellen
+    -   PEGs können manche nicht-CFG Sprachen darstellen (z.B. $a^n b^n c^n$)
+    -   ungelöste Frage: Sind alle CFGs durch PEGs darstellbar?
+    :::
 
-:::slides
-- andere Sprachklasse als CFGs
-- parsebar in linearer Zeit mit unbegrenztem Lookahead (Packrat
-  Parsing)
-    - Nachteil: gesamter zu parsender Text muss im Speicher gehalten werden
-- neue Möglichkeiten für das Syntax-Design von Sprachen
-- Syntaxbeschreibung: keine Unterscheidung zwischen Hierarchie und
-  lexikalischen Elementen nötig
-- Herausforderung bei PEGs:
-    - sind Alternativen vertauschbar, ohne die Sprache zu ändern?
-    - Analog zur Frage der Mehrdeutigkeit bei CFGs
+-   parsebar in linearer Zeit mit unbegrenztem Lookahead (Packrat
+    Parsing)
 
-:::
+    -   Nachteil: gesamter zu parsender Text muss im Speicher gehalten werden
+
+    \smallskip
+
+    ::: notes
+    -   Speicherplatz ist heute aber keine große Einschränkung mehr
+    -   Quellcode-Dateien sind meist nur im KB-Bereich
+    :::
+
+-   neue Möglichkeiten für das Syntax-Design von Sprachen
+
+    ::: notes
+    -   aber auch neue Möglichkeiten für Fehler durch Unachtsamkeit
+    :::
+
+-   Syntaxbeschreibung: keine Unterscheidung zwischen Hierarchie und
+    lexikalischen Elementen nötig
+
+    ::: notes
+    -   für gewöhnlich Hierarchie durch CFG und lex. Elem. durch RE beschrieben
+        -   CFGs ungeeignet für lex. Elemente (keine Greedy-Matching, keine 'negative' Syntax)
+        -   REs: keine rekursive Syntax
+    -   Tokens können hierarchische Eigenschaften haben (verschachtelte Kommentare)
+    -   beliebige Escape-Sequenzen möglich
+    :::
+
+-   Herausforderung bei PEGs:
+    -   sind Alternativen vertauschbar, ohne die Sprache zu ändern?
+    -   Analog zur Frage der Mehrdeutigkeit bei CFGs
+
 
 ## Beispiel: Formeln
 


### PR DESCRIPTION
Beispiel, wie man auf der einen Folien "PEG Beispiele" die `::: notes ... :::` in die Slides mischen könnte

Nachteil: aus der Aufzählungsliste wird eine "loose list", d.h. da ist leider dann mehr Abstand zwischen den Items

